### PR TITLE
feature: fix network creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: Docker Traefik
 
-[![Build Status](https://travis-ci.org/tschifftner/ansible-role-docker-traefik.svg?branch=master)](https://travis-ci.org/tschifftner/ansible-role-docker-traefik)
+[![Build Status](https://travis-ci.org/ambimax/ansible-role-docker-traefik.svg?branch=master)](https://travis-ci.org/ambimax/ansible-role-docker-traefik)
 
 Installs traefik for docker on Debian/Ubuntu linux servers.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ traefik_image: traefik:1.7
 traefik_log_level: ERROR
 traefik_networks:
   - traefik
+traefik_network_scope: swarm
 traefik_onhostrule: true
 traefik_state: started
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,7 +64,9 @@
     appends: true
     driver: bridge
     name: "{{ item }}"
+    attachable: true
     connected: traefik
+    scope: "{{ traefik_network_scope }}"
     state: present
   with_items: "{{ traefik_networks }}"
   ignore_errors: true


### PR DESCRIPTION
This PR will fix the network creation for traefik. Currently the network is created in scope "local" but it must be created in scope "swarm" for traefik to work in swarm clusters. This PR adds a traefik_network_scope variable which allows the user to specify that scope. It defaults to "swarm".